### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setuptools.setup(
     url="https://github.com/jsbronder/asyncio-dgram",
     author="Justin Bronder",
     author_email="jsbronder@cold-front.org",
+    license="MIT",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Allow third-party tools, e.g., PyPI, to get the used license in a simple way.